### PR TITLE
[cruise-control] new release: cc2.5.138-iam2.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ ARG OPENJDK_VERSION=17
 
 FROM amazoncorretto:${OPENJDK_VERSION} as base
 
-ARG CC_TAG=2.5.137
+ARG CC_TAG=2.5.138
 ARG CC_UI_TAG=0.4.0
-ARG AWS_MSK_IAM_AUTH_VERSION=2.1.1
+ARG AWS_MSK_IAM_AUTH_VERSION=2.2.0
 
 RUN yum install -y wget git tar                                                                                              && \
     git clone -b ${CC_TAG} https://github.com/linkedin/cruise-control.git                                                    && \


### PR DESCRIPTION
Cruise Control version:
  - :information_source: Current: `2.5.137`
  - :up: Upgrade: `2.5.138`
  - Changelog: https://github.com/linkedin/cruise-control/releases/tag/2.5.138

AWS IAM Auth version:
  - :information_source: Current: `2.1.1`
  - :up: Upgrade: `2.2.0`
  - Changelog: https://github.com/aws/aws-msk-iam-auth/releases/tag/v2.2.0


