### PR TITLE
[cruise-control] new release: cc3.0.2-iam2.3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM amazoncorretto:${OPENJDK_VERSION} as base
 
 ARG CC_TAG=3.0.2
 ARG CC_UI_TAG=0.4.0
-ARG AWS_MSK_IAM_AUTH_VERSION=2.3.1
+ARG AWS_MSK_IAM_AUTH_VERSION=2.3.2
 
 RUN yum install -y wget git tar                                                                                              && \
     git clone -b ${CC_TAG} https://github.com/linkedin/cruise-control.git                                                    && \


### PR DESCRIPTION
AWS IAM Auth version:
  - :information_source: Current: `2.3.1`
  - :up: Upgrade: `2.3.2`
  - Changelog: https://github.com/aws/aws-msk-iam-auth/releases/tag/v2.3.2


